### PR TITLE
Moved kernel image to Amazon S3

### DIFF
--- a/EnhancedDigitalOutputMeta.lua
+++ b/EnhancedDigitalOutputMeta.lua
@@ -27,7 +27,7 @@ oo.class(_M, AppletMeta)
 
 -- custom kernel configuration
 local USB_KERNEL_VERSION = 1
-local USB_KERNEL_URL     = "http://ralph_irving.users.sourceforge.net/edo/kernel-digitalout-1.bin"
+local USB_KERNEL_URL     = "http://s3.amazonaws.com/enhanced-digital-output/kernel-digitalout-1.bin"
 local USB_KERNEL_MD5     = "b1df8c851322d1b2bba0d1507e7e8f2e"
 
 


### PR DESCRIPTION
The plugin failed to download the kernel image. I believe the problem was due to the SSL certificate served by Sourceforge not matching the domain. Created an S3 bucket and put the binary there, changed the download URL and the plugin worked.
